### PR TITLE
Ensure proper handling of socket reconnects

### DIFF
--- a/src/SocketClient.ts
+++ b/src/SocketClient.ts
@@ -70,6 +70,7 @@ export class SocketClient {
             [id : string] : (data: any) => any
         }
     } = {};
+    private isListenerRegistered: boolean;
 
     /**
      * The main way to create the socket based client.
@@ -90,12 +91,15 @@ export class SocketClient {
 
     private _connected(){
         debug("connected", this.socket.id)
-        // console.log("Connected!", this.socket.id)
-        if(!this.ev) this.ev = new EventEmitter2({
-            wildcard:true
-        })
-        this.socket.emit("register_ev");
-        this.socket.onAny((event, value)=>this.ev.emit(event, value))
+
+        if (!this.isListenerRegistered) {
+            if(!this.ev) this.ev = new EventEmitter2({
+                wildcard:true
+            })
+            this.socket.emit("register_ev");
+            this.socket.onAny((event, value)=>this.ev.emit(event, value))
+            this.isListenerRegistered = true;
+        }
     }
 
     public async createMessageCollector(c : Message | ChatId | Chat, filter : CollectorFilter<[Message]>, options : CollectorOptions) : Promise<MessageCollector> {


### PR DESCRIPTION
This PR addresses an issue with socket reconnects by adding a check to see if an event listener has already been registered before registering it again. This improves the performance of the application by avoiding unnecessary event registration and handling. The `isListenerRegistered` boolean flag is used to keep track of the current state of the event listener.

This change is necessary to ensure proper handling of socket reconnects. Without this check, the socket event listener would be registered multiple times, causing duplicate events to be emitted and handled. This can lead to unexpected behavior and performance issues in the application.

This change also includes the necessary initialization of event emitter if it's not initialized before.

Additionally, this PR also ensures that the register_ev event is only emitted once, preventing the socket server from registering duplicate event handlers, as seem in the link below.

https://github.com/open-wa/wa-automate-nodejs/blob/20832e3deee649193f3e55d66959a14cc34b18f7/src/cli/server.ts#L456
